### PR TITLE
added condition to run only job service array is not empty

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -73,7 +73,7 @@ jobs:
     needs:
       determine-changes
       # This conditional is crucial: only run this job if the services array is not empty
-    if: ${{ needs.determine-changes.outputs.services != '[]' }}
+    if: ${{ fromJson(needs.determine-changes.outputs.services).length > 0  }}
     # Use the JSON output from the previous job to dynamically define the matrix
     strategy:
       matrix:


### PR DESCRIPTION
The fix involves changing if: ${{ needs.determine-changes.outputs.services != '[]' }} to if: ${{ fromJson(needs.determine-changes.outputs.services).length > 0 }}. This is a much more robust way to handle the output and should resolve the issue once and for all. Let's give it a try.